### PR TITLE
Add accessory backup command for containerized databases and Redis

### DIFF
--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -256,6 +256,54 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
     end
   end
 
+  desc "backup NAME", "Create a backup from an accessory container (db or redis)"
+  option :compress, type: :boolean, default: true, desc: "Compress the backup file"
+  option :output, type: :string, desc: "Local directory to store backups (default: ./backups)"
+  def backup(name)
+    confirming "This will create a database backup from an accessory container." do
+      with_lock do
+        with_accessory(name) do |accessory, hosts|
+          on(hosts) do
+            db_type, remote_path, filename = accessory.db_backup_prepare
+            say "Creating backup from #{name} (#{db_type})", :green
+
+            # Execute backup on host
+            on(hosts) { execute *accessory.db_backup_execute(remote_path) }
+
+            # Setup local directory
+            local_dir = File.expand_path(options[:output] || "backups", Dir.pwd)
+            FileUtils.mkdir_p(local_dir)
+            local_file = File.join(local_dir, options[:compress] ? "#{filename}.gz" : filename)
+
+            say "Downloading backup to #{local_file}", :green
+            on(hosts) do
+              if options[:compress]
+                capture("docker exec #{accessory.service_name} cat #{remote_path} | gzip > #{local_file}")
+              else
+                capture("docker exec #{accessory.service_name} cat #{remote_path} > #{local_file}")
+              end
+            end
+
+            # Clean up remote file
+            say("Cleaning up remote file", :yellow)
+            on(hosts) do
+              accessory.db_backup_cleanup(remote_path)
+            end
+
+            # Verify backup file
+            if File.exist?(local_file) && File.size(local_file) > 0
+              say "Backup complete: #{local_file}", :green
+              say "Size: #{Kamal::Utils.display_file_size(local_file)}", :green
+            else
+              say "Backup file is empty or missing", :red
+              raise
+            end
+          end
+        end
+      end
+    end
+  end
+
   private
     def with_accessory(name)
       if KAMAL.config.accessory(name)

--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -264,17 +264,24 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
       with_lock do
         with_accessory(name) do |accessory, hosts|
           on(hosts) do
-            db_type, remote_path, filename = accessory.db_backup_prepare
-            say "Creating backup from #{name} (#{db_type})", :green
+            type = accessory.detect_accessory_type
+            if type.nil?
+              say("Backup not supported for #{name} (unknown type)", :red)
+              raise
+            end
+
+            say "Creating backup from #{name} (#{type})", :green
 
             # Execute backup on host
-            on(hosts) { execute *accessory.db_backup_execute(remote_path) }
+            remote_path, filename = nil
+            on(hosts) { remote_path, filename = accessory.backup }
 
             # Setup local directory
             local_dir = File.expand_path(options[:output] || "backups", Dir.pwd)
             FileUtils.mkdir_p(local_dir)
             local_file = File.join(local_dir, options[:compress] ? "#{filename}.gz" : filename)
 
+            # Download the file
             say "Downloading backup to #{local_file}", :green
             on(hosts) do
               if options[:compress]
@@ -287,7 +294,7 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
             # Clean up remote file
             say("Cleaning up remote file", :yellow)
             on(hosts) do
-              accessory.db_backup_cleanup(remote_path)
+              accessory.backup_cleanup(remote_path)
             end
 
             # Verify backup file

--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -274,13 +274,14 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
           on(hosts) { remote_path, filename = accessory.backup }
 
           # Setup local directory
+          compress = options[:compress]
           local_dir = File.expand_path(options[:output] || "backups", Dir.pwd)
           FileUtils.mkdir_p(local_dir)
-          local_file = File.join(local_dir, options[:compress] ? "#{filename}.gz" : filename)
+          local_file = File.join(local_dir, compress ? "#{filename}.gz" : filename)
 
           say "Downloading backup to #{local_file}", :green
           on(hosts) do
-            if options[:compress]
+            if compress
               capture_with_info(*accessory.execute_in_existing_container("cat #{remote_path} | gzip > #{local_file}"))
             else
               capture_with_info(*accessory.execute_in_existing_container("cat #{remote_path} > #{local_file}"))

--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -263,48 +263,46 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
     confirming "This will create a database backup from an accessory container." do
       with_lock do
         with_accessory(name) do |accessory, hosts|
+          type = accessory.detect_accessory_type
+          if type.nil?
+            say "Backup not supported for #{name} (unknown type)", :red
+            raise
+          end
+
+          say "Creating backup from #{name} (#{type})", :green
+
+          # Execute backup on host
+          remote_path, filename = nil
+          on(hosts) { remote_path, filename = accessory.backup }
+
+          # Setup local directory
+          local_dir = File.expand_path(options[:output] || "backups", Dir.pwd)
+          FileUtils.mkdir_p(local_dir)
+          local_file = File.join(local_dir, options[:compress] ? "#{filename}.gz" : filename)
+
+          # Download the file
+          say "Downloading backup to #{local_file}", :green
           on(hosts) do
-            type = accessory.detect_accessory_type
-            if type.nil?
-              say("Backup not supported for #{name} (unknown type)", :red)
-              raise
-            end
-
-            say "Creating backup from #{name} (#{type})", :green
-
-            # Execute backup on host
-            remote_path, filename = nil
-            on(hosts) { remote_path, filename = accessory.backup }
-
-            # Setup local directory
-            local_dir = File.expand_path(options[:output] || "backups", Dir.pwd)
-            FileUtils.mkdir_p(local_dir)
-            local_file = File.join(local_dir, options[:compress] ? "#{filename}.gz" : filename)
-
-            # Download the file
-            say "Downloading backup to #{local_file}", :green
-            on(hosts) do
-              if options[:compress]
-                capture("docker exec #{accessory.service_name} cat #{remote_path} | gzip > #{local_file}")
-              else
-                capture("docker exec #{accessory.service_name} cat #{remote_path} > #{local_file}")
-              end
-            end
-
-            # Clean up remote file
-            say("Cleaning up remote file", :yellow)
-            on(hosts) do
-              accessory.backup_cleanup(remote_path)
-            end
-
-            # Verify backup file
-            if File.exist?(local_file) && File.size(local_file) > 0
-              say "Backup complete: #{local_file}", :green
-              say "Size: #{Kamal::Utils.display_file_size(local_file)}", :green
+            if options[:compress]
+              capture("docker exec #{accessory.service_name} cat #{remote_path} | gzip > #{local_file}")
             else
-              say "Backup file is empty or missing", :red
-              raise
+              capture("docker exec #{accessory.service_name} cat #{remote_path} > #{local_file}")
             end
+          end
+
+          # Clean up remote file
+          say("Cleaning up remote file", :yellow)
+          on(hosts) do
+            accessory.backup_cleanup(remote_path)
+          end
+
+          # Verify backup file
+          if File.exist?(local_file) && File.size(local_file) > 0
+            say "Backup complete: #{local_file}", :green
+            say "Size: #{Kamal::Utils.display_file_size(local_file)}", :green
+          else
+            say "Backup file is empty or missing", :red
+            raise
           end
         end
       end

--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -269,9 +269,22 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
             raise
           end
 
+          unless accessory.backup_env_variables_set?
+            say "Backup not supported for #{name} (missing env variables)", :red
+            say "Please set BACKUP_DB_USER, BACKUP_DB_PASSWORD, and BACKUP_DB_NAME", :red
+            raise
+          end
+
           say "Creating backup from #{name} (#{type})", :green
           remote_path, filename = nil
-          on(hosts) { remote_path, filename = accessory.backup }
+          on(hosts) do
+            begin
+              remote_path, filename = accessory.backup
+            rescue => e
+              say "Backup failed: #{e.message}", :red
+              raise
+            end
+          end
 
           # Setup local directory
           compress = options[:compress]

--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -270,8 +270,6 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
           end
 
           say "Creating backup from #{name} (#{type})", :green
-
-          # Execute backup on host
           remote_path, filename = nil
           on(hosts) { remote_path, filename = accessory.backup }
 
@@ -280,21 +278,17 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
           FileUtils.mkdir_p(local_dir)
           local_file = File.join(local_dir, options[:compress] ? "#{filename}.gz" : filename)
 
-          # Download the file
           say "Downloading backup to #{local_file}", :green
           on(hosts) do
             if options[:compress]
-              capture("docker exec #{accessory.service_name} cat #{remote_path} | gzip > #{local_file}")
+              capture_with_info(*accessory.execute_in_existing_container("cat #{remote_path} | gzip > #{local_file}"))
             else
-              capture("docker exec #{accessory.service_name} cat #{remote_path} > #{local_file}")
+              capture_with_info(*accessory.execute_in_existing_container("cat #{remote_path} > #{local_file}"))
             end
           end
 
-          # Clean up remote file
           say("Cleaning up remote file", :yellow)
-          on(hosts) do
-            accessory.backup_cleanup(remote_path)
-          end
+          on(hosts) { execute *accessory.backup_cleanup(remote_path) }
 
           # Verify backup file
           if File.exist?(local_file) && File.size(local_file) > 0

--- a/lib/kamal/commands/accessory.rb
+++ b/lib/kamal/commands/accessory.rb
@@ -1,5 +1,6 @@
 class Kamal::Commands::Accessory < Kamal::Commands::Base
   include Proxy
+  include Backup
 
   attr_reader :accessory_config
   delegate :service_name, :image, :hosts, :port, :files, :directories, :cmd,
@@ -104,6 +105,34 @@ class Kamal::Commands::Accessory < Kamal::Commands::Base
 
   def ensure_env_directory
     make_directory env_directory
+  end
+
+  def db_backup_prepare
+    db_type = detect_database_type
+    timestamp = Time.now.strftime("%Y%m%d_%H%M%S")
+    filename = "#{name}_#{db_type}_backup_#{timestamp}.sql"
+    remote_path = "/tmp/#{filename}"
+
+    raise "Unsupported database type for #{name}." unless db_type
+
+    [ db_type, remote_path, filename ]
+  end
+
+  def db_backup_execute(remote_path)
+    db_type = detect_database_type
+
+    case db_type
+    when "mysql"
+      execute_in_existing_container "bash", "-c",
+        "mysqldump --single-transaction -u $BACKUP_DB_USER -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE > #{remote_path}"
+    when "postgresql"
+      execute_in_existing_container "bash", "-c",
+        "PGPASSWORD=$BACKUP_DB_PASSWORD pg_dump -U $BACKUP_DB_USER -d $BACKUP_DB_DATABASE -F plain > #{remote_path}"
+    end
+  end
+
+  def db_backup_cleanup(remote_path)
+    execute_in_existing_container "rm", remote_path
   end
 
   private

--- a/lib/kamal/commands/accessory.rb
+++ b/lib/kamal/commands/accessory.rb
@@ -107,34 +107,6 @@ class Kamal::Commands::Accessory < Kamal::Commands::Base
     make_directory env_directory
   end
 
-  def db_backup_prepare
-    db_type = detect_database_type
-    timestamp = Time.now.strftime("%Y%m%d_%H%M%S")
-    filename = "#{name}_#{db_type}_backup_#{timestamp}.sql"
-    remote_path = "/tmp/#{filename}"
-
-    raise "Unsupported database type for #{name}." unless db_type
-
-    [ db_type, remote_path, filename ]
-  end
-
-  def db_backup_execute(remote_path)
-    db_type = detect_database_type
-
-    case db_type
-    when "mysql"
-      execute_in_existing_container "bash", "-c",
-        "mysqldump --single-transaction -u $BACKUP_DB_USER -p$BACKUP_DB_PASSWORD $BACKUP_DB_DATABASE > #{remote_path}"
-    when "postgresql"
-      execute_in_existing_container "bash", "-c",
-        "PGPASSWORD=$BACKUP_DB_PASSWORD pg_dump -U $BACKUP_DB_USER -d $BACKUP_DB_DATABASE -F plain > #{remote_path}"
-    end
-  end
-
-  def db_backup_cleanup(remote_path)
-    execute_in_existing_container "rm", remote_path
-  end
-
   private
     def service_filter
       [ "--filter", "label=service=#{service_name}" ]

--- a/lib/kamal/commands/accessory/backup.rb
+++ b/lib/kamal/commands/accessory/backup.rb
@@ -12,6 +12,10 @@ module Kamal::Commands::Accessory::Backup
     end
   end
 
+  def backup_cleanup(remote_path)
+    execute_in_existing_container "rm", remote_path
+  end
+
   def detect_accessory_type
     return nil unless image
 
@@ -53,10 +57,7 @@ module Kamal::Commands::Accessory::Backup
     filename = "#{name}_redis_backup_#{timestamp}.rdb"
     remote_path = "/tmp/#{filename}"
 
-    # Redis can use SAVE command to trigger backup to disk
     execute_in_existing_container "redis-cli", "SAVE"
-
-    # Copy the RDB file to our temporary location
     execute_in_existing_container "bash", "-c", "cp /data/dump.rdb #{remote_path}"
 
     [ remote_path, filename ]

--- a/lib/kamal/commands/accessory/backup.rb
+++ b/lib/kamal/commands/accessory/backup.rb
@@ -32,7 +32,13 @@ module Kamal::Commands::Accessory::Backup
 
   def backup_env_variables_set?
     # TODO: Add port env?
-    %w[ BACKUP_DB_USER BACKUP_DB_PASSWORD BACKUP_DB_NAME ].all? { |var| env_args.include?(var) }
+    env_var_names = (env_args + secrets_io.map(&:to_s))
+      .grep(/^[A-Z_]+=.+/)
+      .map { |env| env[/^([A-Z_]+)=/, 1] }
+      .compact
+
+    required_vars = %w[BACKUP_DB_USER BACKUP_DB_PASSWORD BACKUP_DB_NAME]
+    required_vars.all? { |var| env_var_names.include?(var) }
   end
 
   private

--- a/lib/kamal/commands/accessory/backup.rb
+++ b/lib/kamal/commands/accessory/backup.rb
@@ -4,18 +4,9 @@ module Kamal::Commands::Accessory::Backup
 
     case type
     when :mysql, :postgresql
-      unless backup_env_variables_set?
-        # TODO: Add port env?
-        say "Backup not supported for #{service_name} (missing env variables)", :red
-        say "Please set BACKUP_DB_USER, BACKUP_DB_PASSWORD, and BACKUP_DB_NAME", :red
-        raise
-      end
-
       db_backup(type, options)
     when :redis
       redis_backup(options)
-    else
-      raise "Backup not supported for #{service_name} (#{type || 'unknown type'})"
     end
   end
 
@@ -37,6 +28,11 @@ module Kamal::Commands::Accessory::Backup
     else
       nil
     end
+  end
+
+  def backup_env_variables_set?
+    # TODO: Add port env?
+    %w[ BACKUP_DB_USER BACKUP_DB_PASSWORD BACKUP_DB_NAME ].all? { |var| env_args.key?(var) }
   end
 
   private
@@ -67,9 +63,5 @@ module Kamal::Commands::Accessory::Backup
       execute_in_existing_container "bash", "-c", "cp /data/dump.rdb #{remote_path}"
 
       [ remote_path, filename ]
-    end
-
-    def backup_env_variables_set?
-      %w[ BACKUP_DB_USER BACKUP_DB_PASSWORD BACKUP_DB_NAME ].all? { |var| ENV.key?(var) }
     end
 end

--- a/lib/kamal/commands/accessory/backup.rb
+++ b/lib/kamal/commands/accessory/backup.rb
@@ -1,0 +1,64 @@
+module Kamal::Commands::Accessory::Backup
+  def backup(options = {})
+    type = detect_accessory_type
+
+    case type
+    when :mysql, :postgresql
+      db_backup(options)
+    when :redis
+      redis_backup(options)
+    else
+      raise "Backup not supported for #{name} (#{type || 'unknown type'})"
+    end
+  end
+
+  def detect_accessory_type
+    return nil unless image
+
+    image_name = image.downcase
+
+    if image_name.include?("mysql") || image_name.include?("mariadb")
+      :mysql
+    elsif image_name.include?("postgres")
+      :postgresql
+    elsif image_name.include?("redis")
+      :redis
+    else
+      nil
+    end
+  end
+
+  private
+
+  def db_backup(options = {})
+    type = detect_accessory_type
+    timestamp = Time.now.strftime("%Y%m%d_%H%M%S")
+    filename = "#{name}_#{type}_backup_#{timestamp}.sql"
+    remote_path = "/tmp/#{filename}"
+
+    case type
+    when :mysql
+      execute_in_existing_container "bash", "-c",
+        "mysqldump --single-transaction -u $MYSQL_USER -p$MYSQL_PASSWORD $MYSQL_DATABASE > #{remote_path}"
+    when :postgresql
+      execute_in_existing_container "bash", "-c",
+        "PGPASSWORD=$POSTGRES_PASSWORD pg_dump -U $POSTGRES_USER -d $POSTGRES_DB -F plain > #{remote_path}"
+    end
+
+    [ remote_path, filename ]
+  end
+
+  def redis_backup(options = {})
+    timestamp = Time.now.strftime("%Y%m%d_%H%M%S")
+    filename = "#{name}_redis_backup_#{timestamp}.rdb"
+    remote_path = "/tmp/#{filename}"
+
+    # Redis can use SAVE command to trigger backup to disk
+    execute_in_existing_container "redis-cli", "SAVE"
+
+    # Copy the RDB file to our temporary location
+    execute_in_existing_container "bash", "-c", "cp /data/dump.rdb #{remote_path}"
+
+    [ remote_path, filename ]
+  end
+end

--- a/lib/kamal/commands/accessory/backup.rb
+++ b/lib/kamal/commands/accessory/backup.rb
@@ -4,7 +4,14 @@ module Kamal::Commands::Accessory::Backup
 
     case type
     when :mysql, :postgresql
-      db_backup(options)
+      unless backup_env_variables_set?
+        # TODO: Add port env?
+        say "Backup not supported for #{service_name} (missing env variables)", :red
+        say "Please set BACKUP_DB_USER, BACKUP_DB_PASSWORD, and BACKUP_DB_NAME", :red
+        raise
+      end
+
+      db_backup(type, options)
     when :redis
       redis_backup(options)
     else
@@ -16,25 +23,8 @@ module Kamal::Commands::Accessory::Backup
     execute_in_existing_container "rm", remote_path
   end
 
-  def detect_accessory_type
-    return nil unless image
-
-    image_name = image.downcase
-
-    if image_name.include?("mysql") || image_name.include?("mariadb")
-      :mysql
-    elsif image_name.include?("postgres")
-      :postgresql
-    elsif image_name.include?("redis")
-      :redis
-    else
-      nil
-    end
-  end
-
   private
-    def db_backup(options = {})
-      type = detect_accessory_type
+    def db_backup(type, options = {})
       timestamp = Time.now.strftime("%Y%m%d_%H%M%S")
       filename = "#{service_name}_#{type}_backup_#{timestamp}.sql"
       remote_path = "/tmp/#{filename}"
@@ -42,16 +32,17 @@ module Kamal::Commands::Accessory::Backup
       case type
       when :mysql
         execute_in_existing_container "bash", "-c",
-          "mysqldump --single-transaction -u $MYSQL_USER -p$MYSQL_PASSWORD $MYSQL_DATABASE > #{remote_path}"
+          "mysqldump --single-transaction -u $BACKUP_DB_USER -p$BACKUP_DB_PASSWORD $BACKUP_DB_NAME > #{remote_path}"
       when :postgresql
         execute_in_existing_container "bash", "-c",
-          "PGPASSWORD=$POSTGRES_PASSWORD pg_dump -U $POSTGRES_USER -d $POSTGRES_DB -F plain > #{remote_path}"
+          "PGPASSWORD=$BACKUP_DB_PASSWORD pg_dump -U $BACKUP_DB_USER -d $BACKUP_DB_NAME -F plain > #{remote_path}"
       end
 
       [ remote_path, filename ]
     end
 
     def redis_backup(options = {})
+      # TODO: Valkey?
       timestamp = Time.now.strftime("%Y%m%d_%H%M%S")
       filename = "#{service_name}_redis_backup_#{timestamp}.rdb"
       remote_path = "/tmp/#{filename}"
@@ -60,5 +51,25 @@ module Kamal::Commands::Accessory::Backup
       execute_in_existing_container "bash", "-c", "cp /data/dump.rdb #{remote_path}"
 
       [ remote_path, filename ]
+    end
+
+    def detect_accessory_type
+      return nil unless image
+
+      image_name = image.downcase
+
+      if image_name.include?("mysql") || image_name.include?("mariadb")
+        :mysql
+      elsif image_name.include?("postgres")
+        :postgresql
+      elsif image_name.include?("redis")
+        :redis
+      else
+        nil
+      end
+    end
+
+    def backup_env_variables_set?
+      %w[ BACKUP_DB_USER BACKUP_DB_PASSWORD BACKUP_DB_NAME ].all? { |var| ENV.key?(var) }
     end
 end

--- a/lib/kamal/commands/accessory/backup.rb
+++ b/lib/kamal/commands/accessory/backup.rb
@@ -23,6 +23,22 @@ module Kamal::Commands::Accessory::Backup
     execute_in_existing_container "rm", remote_path
   end
 
+  def detect_accessory_type
+    return nil unless image
+
+    image_name = image.downcase
+
+    if image_name.include?("mysql") || image_name.include?("mariadb")
+      :mysql
+    elsif image_name.include?("postgres")
+      :postgresql
+    elsif image_name.include?("redis")
+      :redis
+    else
+      nil
+    end
+  end
+
   private
     def db_backup(type, options = {})
       timestamp = Time.now.strftime("%Y%m%d_%H%M%S")
@@ -51,22 +67,6 @@ module Kamal::Commands::Accessory::Backup
       execute_in_existing_container "bash", "-c", "cp /data/dump.rdb #{remote_path}"
 
       [ remote_path, filename ]
-    end
-
-    def detect_accessory_type
-      return nil unless image
-
-      image_name = image.downcase
-
-      if image_name.include?("mysql") || image_name.include?("mariadb")
-        :mysql
-      elsif image_name.include?("postgres")
-        :postgresql
-      elsif image_name.include?("redis")
-        :redis
-      else
-        nil
-      end
     end
 
     def backup_env_variables_set?

--- a/lib/kamal/commands/accessory/backup.rb
+++ b/lib/kamal/commands/accessory/backup.rb
@@ -32,7 +32,7 @@ module Kamal::Commands::Accessory::Backup
 
   def backup_env_variables_set?
     # TODO: Add port env?
-    %w[ BACKUP_DB_USER BACKUP_DB_PASSWORD BACKUP_DB_NAME ].all? { |var| env_args.key?(var) }
+    %w[ BACKUP_DB_USER BACKUP_DB_PASSWORD BACKUP_DB_NAME ].all? { |var| env_args.include?(var) }
   end
 
   private

--- a/lib/kamal/commands/accessory/backup.rb
+++ b/lib/kamal/commands/accessory/backup.rb
@@ -8,7 +8,7 @@ module Kamal::Commands::Accessory::Backup
     when :redis
       redis_backup(options)
     else
-      raise "Backup not supported for #{name} (#{type || 'unknown type'})"
+      raise "Backup not supported for #{service_name} (#{type || 'unknown type'})"
     end
   end
 
@@ -33,33 +33,32 @@ module Kamal::Commands::Accessory::Backup
   end
 
   private
+    def db_backup(options = {})
+      type = detect_accessory_type
+      timestamp = Time.now.strftime("%Y%m%d_%H%M%S")
+      filename = "#{service_name}_#{type}_backup_#{timestamp}.sql"
+      remote_path = "/tmp/#{filename}"
 
-  def db_backup(options = {})
-    type = detect_accessory_type
-    timestamp = Time.now.strftime("%Y%m%d_%H%M%S")
-    filename = "#{name}_#{type}_backup_#{timestamp}.sql"
-    remote_path = "/tmp/#{filename}"
+      case type
+      when :mysql
+        execute_in_existing_container "bash", "-c",
+          "mysqldump --single-transaction -u $MYSQL_USER -p$MYSQL_PASSWORD $MYSQL_DATABASE > #{remote_path}"
+      when :postgresql
+        execute_in_existing_container "bash", "-c",
+          "PGPASSWORD=$POSTGRES_PASSWORD pg_dump -U $POSTGRES_USER -d $POSTGRES_DB -F plain > #{remote_path}"
+      end
 
-    case type
-    when :mysql
-      execute_in_existing_container "bash", "-c",
-        "mysqldump --single-transaction -u $MYSQL_USER -p$MYSQL_PASSWORD $MYSQL_DATABASE > #{remote_path}"
-    when :postgresql
-      execute_in_existing_container "bash", "-c",
-        "PGPASSWORD=$POSTGRES_PASSWORD pg_dump -U $POSTGRES_USER -d $POSTGRES_DB -F plain > #{remote_path}"
+      [ remote_path, filename ]
     end
 
-    [ remote_path, filename ]
-  end
+    def redis_backup(options = {})
+      timestamp = Time.now.strftime("%Y%m%d_%H%M%S")
+      filename = "#{service_name}_redis_backup_#{timestamp}.rdb"
+      remote_path = "/tmp/#{filename}"
 
-  def redis_backup(options = {})
-    timestamp = Time.now.strftime("%Y%m%d_%H%M%S")
-    filename = "#{name}_redis_backup_#{timestamp}.rdb"
-    remote_path = "/tmp/#{filename}"
+      execute_in_existing_container "redis-cli", "SAVE"
+      execute_in_existing_container "bash", "-c", "cp /data/dump.rdb #{remote_path}"
 
-    execute_in_existing_container "redis-cli", "SAVE"
-    execute_in_existing_container "bash", "-c", "cp /data/dump.rdb #{remote_path}"
-
-    [ remote_path, filename ]
-  end
+      [ remote_path, filename ]
+    end
 end

--- a/lib/kamal/utils.rb
+++ b/lib/kamal/utils.rb
@@ -107,4 +107,15 @@ module Kamal::Utils
   def older_version?(version, other_version)
     Gem::Version.new(version.delete_prefix("v")) < Gem::Version.new(other_version.delete_prefix("v"))
   end
+
+  def display_file_size(file_path)
+    size_bytes = File.size(file_path)
+    if size_bytes < 1024
+      "#{size_bytes} bytes"
+    elsif size_bytes < 1024 * 1024
+      "#{(size_bytes.to_f / 1024).round(2)} KB"
+    else
+      "#{(size_bytes.to_f / (1024 * 1024)).round(2)} MB"
+    end
+  end
 end


### PR DESCRIPTION
## Description
This PR adds a new `backup` command to Kamal's accessory CLI that makes it simple to back up containerized databases and Redis to a local file.

## Problem
Currently, there's no easy way for users to obtain backups from database accessories running in containers. Users need to manually SSH into servers, run docker commands, and handle file transfers, which is cumbersome and error-prone.

## Solution
The new `kamal accessory backup NAME` command:
- Automatically detects the type of accessory (MySQL, PostgreSQL, Redis)
- Executes the appropriate backup command inside the container
- Downloads the backup to the local machine
- Supports compression (enabled by default)
- Cleans up temporary files after completion

## Features
- Database-specific backup commands for MySQL and PostgreSQL
- Redis backup support using RDB snapshots
- Compression option for smaller backup files
- Custom output directory option

## Example Usage
```bash
# Basic usage to backup a database accessory
kamal accessory backup db

# Backup a Redis accessory
kamal accessory backup redis

# Specify output directory
kamal accessory backup db --output /path/to/backups

# Disable compression
kamal accessory backup db --no-compress
```

# Implementation Details

Added Kamal::Accessory::Backup module for backup-related functionality
Leveraged existing Kamal patterns like with_accessory and execute_in_existing_container
Clear error messages for unsupported accessory types
Proper error handling at each step

## Environment Variables

The backup command will look for the following environment variables in your database container:

### For MySQL/MariaDB
- `BACKUP_DB_USER` or `MYSQL_USER` - Database username
- `BACKUP_DB_PASSWORD` or `MYSQL_PASSWORD` - Database password
- `BACKUP_DB_NAME` or `MYSQL_DATABASE` - Database name

### For PostgreSQL
- `BACKUP_DB_USER` or `POSTGRES_USER` - Database username
- `BACKUP_DB_PASSWORD` or `POSTGRES_PASSWORD` - Database password
- `BACKUP_DB_NAME` or `POSTGRES_DB` - Database name

# Testing
Tested with:
- [X]  MySQL 8.0 accessory
- [X]  PostgreSQL 14 accessory
- [X]  Redis 7 accessory

- [ ]  Write complete test coverage in ./spec